### PR TITLE
Change strict dependency on tighenco/collect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-		"tightenco/collect": "5.6.35",
+		"tightenco/collect": "^5.6.35",
 		"guzzlehttp/guzzle": "^6.3"
     },
     "autoload": {


### PR DESCRIPTION
I've changed the composer.json file to allow for dependencies on newer versions of tightenco/collect.
Fixes #9 